### PR TITLE
Updated DBFCI, UNICLR, GameDef, and both ImgDat files

### DIFF
--- a/palmod/Game/GameDef.h
+++ b/palmod/Game/GameDef.h
@@ -207,7 +207,7 @@ const WCHAR g_GameFriendlyName[NUM_GAMES][64] =
    L"Rage of the Dragons (Neo-Geo)",
    L"Garou: MotW (Neo-Geo Prototype)",
    L"Dengeki Bunko: Fighting Climax IGNITION",
-   L"Under Night In-Birth Exe:Late[clr-r]",
+   L"Under Night In-Birth Exe:Late[cl-r]",
    L"Super Puzzle Fighter II Turbo",
 };
 
@@ -3322,86 +3322,82 @@ enum SupportedGGXX_PaletteListIndex
     indexGGXXSprites_ACR_Bonus,             // 0x19
 };
 
-enum SupportedDBFC_PaletteListIndex
-{
-    indexDBFCSprites_DBFCI_Akira,        // 0x00
-    indexDBFCSprites_DBFCI_Ako,          // 0x01
-    indexDBFCSprites_DBFCI_Asuna,        // 0x02
-    indexDBFCSprites_DBFCI_Emi,          // 0x03
-    indexDBFCSprites_DBFCI_Kirino,       // 0x04
-    indexDBFCSprites_DBFCI_Kirito,       // 0x05
-    indexDBFCSprites_DBFCI_Kuroko,       // 0x06
-    indexDBFCSprites_DBFCI_Kuroyukihime, // 0x07
-    indexDBFCSprites_DBFCI_Mikoto,       // 0x08
-    indexDBFCSprites_DBFCI_Miyuki,       // 0x09
-    indexDBFCSprites_DBFCI_Quenser,      // 0x0A
-    indexDBFCSprites_DBFCI_Rentaro,      // 0x0B
-    indexDBFCSprites_DBFCI_Selvaria,     // 0x0C
-    indexDBFCSprites_DBFCI_Shana,        // 0x0D
-    indexDBFCSprites_DBFCI_Shizuo,       // 0x0E
-    indexDBFCSprites_DBFCI_Taiga,        // 0x0F
-    indexDBFCSprites_DBFCI_Tatsuya,      // 0x10
-    indexDBFCSprites_DBFCI_Tomoka,       // 0x11
-    indexDBFCSprites_DBFCI_Yukina,       // 0x12
-    indexDBFCSprites_DBFCI_Yuuki,        // 0x13
-    indexDBFCSprites_DBFCI_AcceleratorLastOrder, // 0x14
-    indexDBFCSprites_DBFCI_Alicia,        // 0x15
-    indexDBFCSprites_DBFCI_Arita,         // 0x16
-    indexDBFCSprites_DBFCI_Boogiepop,     // 0x17
-    indexDBFCSprites_DBFCI_Celty,         // 0x18
-    indexDBFCSprites_DBFCI_DokuroChan,    // 0x19
-    indexDBFCSprites_DBFCI_Enju,          // 0x1A
-    indexDBFCSprites_DBFCI_Erio,          // 0x1B
-    indexDBFCSprites_DBFCI_Frolaytia,     // 0x1C
-    indexDBFCSprites_DBFCI_Holo,          // 0x1D
-    indexDBFCSprites_DBFCI_InnocentCharm, // 0x1E
-    indexDBFCSprites_DBFCI_Izaya,         // 0x1F
-    indexDBFCSprites_DBFCI_Kana,          // 0x20
-    indexDBFCSprites_DBFCI_Kazari,        // 0x21
-    indexDBFCSprites_DBFCI_Kino,          // 0x22
-    indexDBFCSprites_DBFCI_Kojou,         // 0x23
-    indexDBFCSprites_DBFCI_Kokou,         // 0x24
-    indexDBFCSprites_DBFCI_Kuroneko,      // 0x25
-    indexDBFCSprites_DBFCI_Leafa,         // 0x26
-    indexDBFCSprites_DBFCI_Llenn,         // 0x27
-    indexDBFCSprites_DBFCI_Mashiro,       // 0x28
-    indexDBFCSprites_DBFCI_MiyukiAssist,  // 0x29
-    indexDBFCSprites_DBFCI_PaiChan,       // 0x2A
-    indexDBFCSprites_DBFCI_Rusian,        // 0x2B
-    indexDBFCSprites_DBFCI_Ryuji,         // 0x2C
-    indexDBFCSprites_DBFCI_Sadao,         // 0x2D
-    indexDBFCSprites_DBFCI_TatsuyaAssist, // 0x2E
-    indexDBFCSprites_DBFCI_Tomo,          // 0x2F
-    indexDBFCSprites_DBFCI_Touma,         // 0x30
-    indexDBFCSprites_DBFCI_Wilhelmina,    // 0x31
-    indexDBFCSprites_DBFCI_Zero,          // 0x32
-    indexDBFCSprites_DBFCI_Bonus,         // 0x33
-};
-
 enum SupportedFrenchBread_PaletteListIndex
 {
-    indexFrenchBreadSprites_UNICLR_Akat,   // 0x00
-    indexFrenchBreadSprites_UNICLR_Byak,   // 0x01
-    indexFrenchBreadSprites_UNICLR_Carm,   // 0x02
-    indexFrenchBreadSprites_UNICLR_Chao,   // 0x03
-    indexFrenchBreadSprites_UNICLR_Eltn,   // 0x04
-    indexFrenchBreadSprites_UNICLR_Enki,   // 0x05
-    indexFrenchBreadSprites_UNICLR_Gord,   // 0x06
-    indexFrenchBreadSprites_UNICLR_Hild,   // 0x07
-    indexFrenchBreadSprites_UNICLR_Hyde,   // 0x08
-    indexFrenchBreadSprites_UNICLR_Linn,   // 0x09
-    indexFrenchBreadSprites_UNICLR_Lond,   // 0x0A
-    indexFrenchBreadSprites_UNICLR_Merk,   // 0x0B
-    indexFrenchBreadSprites_UNICLR_Mika,   // 0x0C
-    indexFrenchBreadSprites_UNICLR_Nana,   // 0x0D
-    indexFrenchBreadSprites_UNICLR_Orie,   // 0x0E
-    indexFrenchBreadSprites_UNICLR_Phon,   // 0x0F
-    indexFrenchBreadSprites_UNICLR_Seth,   // 0x10
-    indexFrenchBreadSprites_UNICLR_Vati,   // 0x11
-    indexFrenchBreadSprites_UNICLR_Wagn,   // 0x12
-    indexFrenchBreadSprites_UNICLR_Wald,   // 0x13
-    indexFrenchBreadSprites_UNICLR_Yuzu,   // 0x14
-    indexFrenchBreadSprites_UNICLR_Bonus,  // 0x15
+    indexFrenchBreadSprites_DBFCI_Akira,        // 0x00
+    indexFrenchBreadSprites_DBFCI_Ako,          // 0x01
+    indexFrenchBreadSprites_DBFCI_Asuna,        // 0x02
+    indexFrenchBreadSprites_DBFCI_Emi,          // 0x03
+    indexFrenchBreadSprites_DBFCI_Kirino,       // 0x04
+    indexFrenchBreadSprites_DBFCI_Kirito,       // 0x05
+    indexFrenchBreadSprites_DBFCI_Kuroko,       // 0x06
+    indexFrenchBreadSprites_DBFCI_Kuroyukihime, // 0x07
+    indexFrenchBreadSprites_DBFCI_Mikoto,       // 0x08
+    indexFrenchBreadSprites_DBFCI_Miyuki,       // 0x09
+    indexFrenchBreadSprites_DBFCI_Quenser,      // 0x0A
+    indexFrenchBreadSprites_DBFCI_Rentaro,      // 0x0B
+    indexFrenchBreadSprites_DBFCI_Selvaria,     // 0x0C
+    indexFrenchBreadSprites_DBFCI_Shana,        // 0x0D
+    indexFrenchBreadSprites_DBFCI_Shizuo,       // 0x0E
+    indexFrenchBreadSprites_DBFCI_Taiga,        // 0x0F
+    indexFrenchBreadSprites_DBFCI_Tatsuya,      // 0x10
+    indexFrenchBreadSprites_DBFCI_Tomoka,       // 0x11
+    indexFrenchBreadSprites_DBFCI_Yukina,       // 0x12
+    indexFrenchBreadSprites_DBFCI_Yuuki,        // 0x13
+    indexFrenchBreadSprites_DBFCI_AcceleratorLastOrder, // 0x14
+    indexFrenchBreadSprites_DBFCI_Alicia,        // 0x15
+    indexFrenchBreadSprites_DBFCI_Arita,         // 0x16
+    indexFrenchBreadSprites_DBFCI_Boogiepop,     // 0x17
+    indexFrenchBreadSprites_DBFCI_Celty,         // 0x18
+    indexFrenchBreadSprites_DBFCI_DokuroChan,    // 0x19
+    indexFrenchBreadSprites_DBFCI_Enju,          // 0x1A
+    indexFrenchBreadSprites_DBFCI_Erio,          // 0x1B
+    indexFrenchBreadSprites_DBFCI_Frolaytia,     // 0x1C
+    indexFrenchBreadSprites_DBFCI_Holo,          // 0x1D
+    indexFrenchBreadSprites_DBFCI_InnocentCharm, // 0x1E
+    indexFrenchBreadSprites_DBFCI_Izaya,         // 0x1F
+    indexFrenchBreadSprites_DBFCI_Kana,          // 0x20
+    indexFrenchBreadSprites_DBFCI_Kazari,        // 0x21
+    indexFrenchBreadSprites_DBFCI_Kino,          // 0x22
+    indexFrenchBreadSprites_DBFCI_Kojou,         // 0x23
+    indexFrenchBreadSprites_DBFCI_Kokou,         // 0x24
+    indexFrenchBreadSprites_DBFCI_Kuroneko,      // 0x25
+    indexFrenchBreadSprites_DBFCI_Leafa,         // 0x26
+    indexFrenchBreadSprites_DBFCI_Llenn,         // 0x27
+    indexFrenchBreadSprites_DBFCI_Mashiro,       // 0x28
+    indexFrenchBreadSprites_DBFCI_MiyukiAssist,  // 0x29
+    indexFrenchBreadSprites_DBFCI_PaiChan,       // 0x2A
+    indexFrenchBreadSprites_DBFCI_Rusian,        // 0x2B
+    indexFrenchBreadSprites_DBFCI_Ryuji,         // 0x2C
+    indexFrenchBreadSprites_DBFCI_Sadao,         // 0x2D
+    indexFrenchBreadSprites_DBFCI_TatsuyaAssist, // 0x2E
+    indexFrenchBreadSprites_DBFCI_Tomo,          // 0x2F
+    indexFrenchBreadSprites_DBFCI_Touma,         // 0x30
+    indexFrenchBreadSprites_DBFCI_Wilhelmina,    // 0x31
+    indexFrenchBreadSprites_DBFCI_Zero,          // 0x32
+	indexFrenchBreadSprites_DBFCI_Bonus,         // 0x33
+	indexFrenchBreadSprites_UNICLR_Akat,   // 0x34
+    indexFrenchBreadSprites_UNICLR_Byak,   // 0x35
+    indexFrenchBreadSprites_UNICLR_Carm,   // 0x36
+    indexFrenchBreadSprites_UNICLR_Chao,   // 0x37
+    indexFrenchBreadSprites_UNICLR_Eltn,   // 0x38
+    indexFrenchBreadSprites_UNICLR_Enki,   // 0x39
+    indexFrenchBreadSprites_UNICLR_Gord,   // 0x3A
+    indexFrenchBreadSprites_UNICLR_Hild,   // 0x3B
+    indexFrenchBreadSprites_UNICLR_Hyde,   // 0x3C
+    indexFrenchBreadSprites_UNICLR_Linn,   // 0x3D
+    indexFrenchBreadSprites_UNICLR_Lond,   // 0x3E
+    indexFrenchBreadSprites_UNICLR_Merk,   // 0x3F
+    indexFrenchBreadSprites_UNICLR_Mika,   // 0x40
+    indexFrenchBreadSprites_UNICLR_Nana,   // 0x41
+    indexFrenchBreadSprites_UNICLR_Orie,   // 0x42
+    indexFrenchBreadSprites_UNICLR_Phon,   // 0x43
+    indexFrenchBreadSprites_UNICLR_Seth,   // 0x44
+    indexFrenchBreadSprites_UNICLR_Vati,   // 0x45
+    indexFrenchBreadSprites_UNICLR_Wagn,   // 0x46
+    indexFrenchBreadSprites_UNICLR_Wald,   // 0x47
+    indexFrenchBreadSprites_UNICLR_Yuzu,   // 0x48
+    indexFrenchBreadSprites_UNICLR_Bonus,  // 0x49
 };
 
 enum SupportedTaito_PaletteListIndex
@@ -3425,8 +3421,7 @@ enum eIMGDat_Sections
     IMGDAT_SECTION_BREAKREV = 0,
     IMGDAT_SECTION_CPS2,    // Used for MVC2, MVC, SFA3, XMVSF, MSH, MSHVSF, etc CPS2 games
     IMGDAT_SECTION_CVS2,    // CVS2: has both Capcom and SNK images
-    IMGDAT_SECTION_DBFC,    // Dengeki Bunko
-    IMGDAT_SECTION_FRENCHBREAD, // UniClr
+    IMGDAT_SECTION_FRENCHBREAD, // Used for DBFCI, UNICLR
     IMGDAT_SECTION_GAROU,
     IMGDAT_SECTION_GUILTYGEAR,
     IMGDAT_SECTION_JOJOS,

--- a/palmod/Game/Game_DBFCI_A.cpp
+++ b/palmod/Game/Game_DBFCI_A.cpp
@@ -10,58 +10,58 @@ CDescTree CGame_DBFCI_A::MainDescTree = nullptr;
 
 const UINT16 DBFCI_A_IMG_UNITS[] =
 {
-    indexDBFCSprites_DBFCI_Akira,        // 0x00
-    indexDBFCSprites_DBFCI_Ako,          // 0x01
-    indexDBFCSprites_DBFCI_Asuna,        // 0x02
-    indexDBFCSprites_DBFCI_Emi,          // 0x03
-    indexDBFCSprites_DBFCI_Kirino,       // 0x04
-    indexDBFCSprites_DBFCI_Kirito,       // 0x05
-    indexDBFCSprites_DBFCI_Kuroko,       // 0x06
-    indexDBFCSprites_DBFCI_Kuroyukihime, // 0x07
-    indexDBFCSprites_DBFCI_Mikoto,       // 0x08
-    indexDBFCSprites_DBFCI_Miyuki,       // 0x09
-    indexDBFCSprites_DBFCI_Quenser,      // 0x0A
-    indexDBFCSprites_DBFCI_Rentaro,      // 0x0B
-    indexDBFCSprites_DBFCI_Selvaria,     // 0x0C
-    indexDBFCSprites_DBFCI_Shana,        // 0x0D
-    indexDBFCSprites_DBFCI_Shizuo,       // 0x0E
-    indexDBFCSprites_DBFCI_Taiga,        // 0x0F
-    indexDBFCSprites_DBFCI_Tatsuya,      // 0x10
-    indexDBFCSprites_DBFCI_Tomoka,       // 0x11
-    indexDBFCSprites_DBFCI_Yukina,       // 0x12
-    indexDBFCSprites_DBFCI_Yuuki,        // 0x13
-    indexDBFCSprites_DBFCI_AcceleratorLastOrder, // 0x14
-    indexDBFCSprites_DBFCI_Alicia,        // 0x15
-    indexDBFCSprites_DBFCI_Arita,         // 0x16
-    indexDBFCSprites_DBFCI_Boogiepop,     // 0x17
-    indexDBFCSprites_DBFCI_Celty,         // 0x18
-    indexDBFCSprites_DBFCI_DokuroChan,    // 0x19
-    indexDBFCSprites_DBFCI_Enju,          // 0x1A
-    indexDBFCSprites_DBFCI_Erio,          // 0x1B
-    indexDBFCSprites_DBFCI_Frolaytia,     // 0x1C
-    indexDBFCSprites_DBFCI_Holo,          // 0x1D
-    indexDBFCSprites_DBFCI_InnocentCharm, // 0x1E
-    indexDBFCSprites_DBFCI_Izaya,         // 0x1F
-    indexDBFCSprites_DBFCI_Kana,          // 0x20
-    indexDBFCSprites_DBFCI_Kazari,        // 0x21
-    indexDBFCSprites_DBFCI_Kino,          // 0x22
-    indexDBFCSprites_DBFCI_Kojou,         // 0x23
-    indexDBFCSprites_DBFCI_Kokou,         // 0x24
-    indexDBFCSprites_DBFCI_Kuroneko,      // 0x25
-    indexDBFCSprites_DBFCI_Leafa,         // 0x26
-    indexDBFCSprites_DBFCI_Llenn,         // 0x27
-    indexDBFCSprites_DBFCI_Mashiro,       // 0x28
-    indexDBFCSprites_DBFCI_MiyukiAssist,  // 0x29
-    indexDBFCSprites_DBFCI_PaiChan,       // 0x2A
-    indexDBFCSprites_DBFCI_Rusian,        // 0x2B
-    indexDBFCSprites_DBFCI_Ryuji,         // 0x2C
-    indexDBFCSprites_DBFCI_Sadao,         // 0x2D
-    indexDBFCSprites_DBFCI_TatsuyaAssist, // 0x2E
-    indexDBFCSprites_DBFCI_Tomo,          // 0x2F
-    indexDBFCSprites_DBFCI_Touma,         // 0x30
-    indexDBFCSprites_DBFCI_Wilhelmina,    // 0x31
-    indexDBFCSprites_DBFCI_Zero,          // 0x32
-    indexDBFCSprites_DBFCI_Bonus,         // 0x33
+    indexFrenchBreadSprites_DBFCI_Akira,        // 0x00
+    indexFrenchBreadSprites_DBFCI_Ako,          // 0x01
+    indexFrenchBreadSprites_DBFCI_Asuna,        // 0x02
+    indexFrenchBreadSprites_DBFCI_Emi,          // 0x03
+    indexFrenchBreadSprites_DBFCI_Kirino,       // 0x04
+    indexFrenchBreadSprites_DBFCI_Kirito,       // 0x05
+    indexFrenchBreadSprites_DBFCI_Kuroko,       // 0x06
+    indexFrenchBreadSprites_DBFCI_Kuroyukihime, // 0x07
+    indexFrenchBreadSprites_DBFCI_Mikoto,       // 0x08
+    indexFrenchBreadSprites_DBFCI_Miyuki,       // 0x09
+    indexFrenchBreadSprites_DBFCI_Quenser,      // 0x0A
+    indexFrenchBreadSprites_DBFCI_Rentaro,      // 0x0B
+    indexFrenchBreadSprites_DBFCI_Selvaria,     // 0x0C
+    indexFrenchBreadSprites_DBFCI_Shana,        // 0x0D
+    indexFrenchBreadSprites_DBFCI_Shizuo,       // 0x0E
+    indexFrenchBreadSprites_DBFCI_Taiga,        // 0x0F
+    indexFrenchBreadSprites_DBFCI_Tatsuya,      // 0x10
+    indexFrenchBreadSprites_DBFCI_Tomoka,       // 0x11
+    indexFrenchBreadSprites_DBFCI_Yukina,       // 0x12
+    indexFrenchBreadSprites_DBFCI_Yuuki,        // 0x13
+    indexFrenchBreadSprites_DBFCI_AcceleratorLastOrder, // 0x14
+    indexFrenchBreadSprites_DBFCI_Alicia,        // 0x15
+    indexFrenchBreadSprites_DBFCI_Arita,         // 0x16
+    indexFrenchBreadSprites_DBFCI_Boogiepop,     // 0x17
+    indexFrenchBreadSprites_DBFCI_Celty,         // 0x18
+    indexFrenchBreadSprites_DBFCI_DokuroChan,    // 0x19
+    indexFrenchBreadSprites_DBFCI_Enju,          // 0x1A
+    indexFrenchBreadSprites_DBFCI_Erio,          // 0x1B
+    indexFrenchBreadSprites_DBFCI_Frolaytia,     // 0x1C
+    indexFrenchBreadSprites_DBFCI_Holo,          // 0x1D
+    indexFrenchBreadSprites_DBFCI_InnocentCharm, // 0x1E
+    indexFrenchBreadSprites_DBFCI_Izaya,         // 0x1F
+    indexFrenchBreadSprites_DBFCI_Kana,          // 0x20
+    indexFrenchBreadSprites_DBFCI_Kazari,        // 0x21
+    indexFrenchBreadSprites_DBFCI_Kino,          // 0x22
+    indexFrenchBreadSprites_DBFCI_Kojou,         // 0x23
+    indexFrenchBreadSprites_DBFCI_Kokou,         // 0x24
+    indexFrenchBreadSprites_DBFCI_Kuroneko,      // 0x25
+    indexFrenchBreadSprites_DBFCI_Leafa,         // 0x26
+    indexFrenchBreadSprites_DBFCI_Llenn,         // 0x27
+    indexFrenchBreadSprites_DBFCI_Mashiro,       // 0x28
+    indexFrenchBreadSprites_DBFCI_MiyukiAssist,  // 0x29
+    indexFrenchBreadSprites_DBFCI_PaiChan,       // 0x2A
+    indexFrenchBreadSprites_DBFCI_Rusian,        // 0x2B
+    indexFrenchBreadSprites_DBFCI_Ryuji,         // 0x2C
+    indexFrenchBreadSprites_DBFCI_Sadao,         // 0x2D
+    indexFrenchBreadSprites_DBFCI_TatsuyaAssist, // 0x2E
+    indexFrenchBreadSprites_DBFCI_Tomo,          // 0x2F
+    indexFrenchBreadSprites_DBFCI_Touma,         // 0x30
+    indexFrenchBreadSprites_DBFCI_Wilhelmina,    // 0x31
+    indexFrenchBreadSprites_DBFCI_Zero,          // 0x32
+	indexFrenchBreadSprites_DBFCI_Bonus,          // 0x33
 };
 
 struct DBFCINodeData
@@ -218,69 +218,70 @@ struct DBFCIFileData
 
 DBFCIFileData DBFCICharacterData[] =
 {
-    { L"Yak.pal",    L"Akira",          65540,    DBFCIPaletteNamesNormal,    ARRAYSIZE(DBFCIPaletteNamesNormal), 0x4,  indexDBFCSprites_DBFCI_Akira },
-    { L"Ako.pal",    L"Ako",            65540,    DBFCIPaletteNamesNormal,    ARRAYSIZE(DBFCIPaletteNamesNormal), 0x4,  indexDBFCSprites_DBFCI_Ako },
-    { L"Asu.pal",    L"Asuna",          65540,    DBFCIPaletteNamesNormal,    ARRAYSIZE(DBFCIPaletteNamesNormal), 0x4,  indexDBFCSprites_DBFCI_Asuna },
-    { L"Emi.pal",    L"Emi",            65540,    DBFCIPaletteNamesNormal,    ARRAYSIZE(DBFCIPaletteNamesNormal), 0x4,  indexDBFCSprites_DBFCI_Emi },
-    { L"Krn.pal",    L"Kirino",         65540,    DBFCIPaletteNamesNormal,    ARRAYSIZE(DBFCIPaletteNamesNormal), 0x4,  indexDBFCSprites_DBFCI_Kirino },
-    { L"Krt.pal",    L"Kirito",         65540,    DBFCIPaletteNamesNormal,    ARRAYSIZE(DBFCIPaletteNamesNormal), 0x4,  indexDBFCSprites_DBFCI_Kirito },
-    { L"Krk.pal",    L"Kuroko",         65540,    DBFCIPaletteNamesNormal,    ARRAYSIZE(DBFCIPaletteNamesNormal), 0x4,  indexDBFCSprites_DBFCI_Kuroko },
-    { L"Kur.pal",    L"Kuroyukihime",   65540,    DBFCIPaletteNamesNormal,    ARRAYSIZE(DBFCIPaletteNamesNormal), 0x4,  indexDBFCSprites_DBFCI_Kuroyukihime },
-    { L"Mis.pal",    L"Mikoto",         65540,    DBFCIPaletteNamesNormal,    ARRAYSIZE(DBFCIPaletteNamesNormal), 0x4,  indexDBFCSprites_DBFCI_Mikoto },
-    { L"Sbm.pal",    L"Miyuki",         66564,    DBFCIPaletteNamesNormal,    ARRAYSIZE(DBFCIPaletteNamesNormal), 0x4,  indexDBFCSprites_DBFCI_Miyuki },
-    { L"Qen.pal",    L"Qwenthur",       65540,    DBFCIPaletteNamesNormal,    ARRAYSIZE(DBFCIPaletteNamesNormal), 0x4,  indexDBFCSprites_DBFCI_Quenser },
-    { L"Stm.pal",    L"Rentaro",        65540,    DBFCIPaletteNamesNormal,    ARRAYSIZE(DBFCIPaletteNamesNormal), 0x4,  indexDBFCSprites_DBFCI_Rentaro },
-    { L"Slv.pal",    L"Selvaria",       65540,    DBFCIPaletteNamesNormal,    ARRAYSIZE(DBFCIPaletteNamesNormal), 0x4,  indexDBFCSprites_DBFCI_Selvaria },
-    { L"Sha.pal",    L"Shana",          65540,    DBFCIPaletteNamesNormal,    ARRAYSIZE(DBFCIPaletteNamesNormal), 0x4,  indexDBFCSprites_DBFCI_Shana },
-    { L"Hiw.pal",    L"Shizuo",         65540,    DBFCIPaletteNamesNormal,    ARRAYSIZE(DBFCIPaletteNamesNormal), 0x4,  indexDBFCSprites_DBFCI_Shizuo },
-    { L"Tgr.pal",    L"Taiga",          65540,    DBFCIPaletteNamesNormal,    ARRAYSIZE(DBFCIPaletteNamesNormal), 0x4,  indexDBFCSprites_DBFCI_Taiga },
-    { L"Oni.pal",    L"Tatsuya",        65540,    DBFCIPaletteNamesNormal,    ARRAYSIZE(DBFCIPaletteNamesNormal), 0x4,  indexDBFCSprites_DBFCI_Tatsuya },
-    { L"Tmk.pal",    L"Tomoka",         65540,    DBFCIPaletteNamesNormal,    ARRAYSIZE(DBFCIPaletteNamesNormal), 0x4,  indexDBFCSprites_DBFCI_Tomoka },
-    { L"Ykn.pal",    L"Yukina",         65540,    DBFCIPaletteNamesNormal,    ARRAYSIZE(DBFCIPaletteNamesNormal), 0x4,  indexDBFCSprites_DBFCI_Yukina },
-    { L"Yuk.pal",    L"Yuuki",          65540,    DBFCIPaletteNamesNormal,    ARRAYSIZE(DBFCIPaletteNamesNormal), 0x4,  indexDBFCSprites_DBFCI_Yuuki },
+    { L"Yak.pal",    L"Akira",          65540,    DBFCIPaletteNamesNormal,    ARRAYSIZE(DBFCIPaletteNamesNormal), 0x4,  indexFrenchBreadSprites_DBFCI_Akira },
+    { L"Ako.pal",    L"Ako",            65540,    DBFCIPaletteNamesNormal,    ARRAYSIZE(DBFCIPaletteNamesNormal), 0x4,  indexFrenchBreadSprites_DBFCI_Ako },
+    { L"Asu.pal",    L"Asuna",          65540,    DBFCIPaletteNamesNormal,    ARRAYSIZE(DBFCIPaletteNamesNormal), 0x4,  indexFrenchBreadSprites_DBFCI_Asuna },
+    { L"Emi.pal",    L"Emi",            65540,    DBFCIPaletteNamesNormal,    ARRAYSIZE(DBFCIPaletteNamesNormal), 0x4,  indexFrenchBreadSprites_DBFCI_Emi },
+    { L"Krn.pal",    L"Kirino",         65540,    DBFCIPaletteNamesNormal,    ARRAYSIZE(DBFCIPaletteNamesNormal), 0x4,  indexFrenchBreadSprites_DBFCI_Kirino },
+    { L"Krt.pal",    L"Kirito",         65540,    DBFCIPaletteNamesNormal,    ARRAYSIZE(DBFCIPaletteNamesNormal), 0x4,  indexFrenchBreadSprites_DBFCI_Kirito },
+    { L"Krk.pal",    L"Kuroko",         65540,    DBFCIPaletteNamesNormal,    ARRAYSIZE(DBFCIPaletteNamesNormal), 0x4,  indexFrenchBreadSprites_DBFCI_Kuroko },
+    { L"Kur.pal",    L"Kuroyukihime",   65540,    DBFCIPaletteNamesNormal,    ARRAYSIZE(DBFCIPaletteNamesNormal), 0x4,  indexFrenchBreadSprites_DBFCI_Kuroyukihime },
+    { L"Mis.pal",    L"Mikoto",         65540,    DBFCIPaletteNamesNormal,    ARRAYSIZE(DBFCIPaletteNamesNormal), 0x4,  indexFrenchBreadSprites_DBFCI_Mikoto },
+    { L"Sbm.pal",    L"Miyuki",         66564,    DBFCIPaletteNamesNormal,    ARRAYSIZE(DBFCIPaletteNamesNormal), 0x4,  indexFrenchBreadSprites_DBFCI_Miyuki },
+    { L"Qen.pal",    L"Qwenthur",       65540,    DBFCIPaletteNamesNormal,    ARRAYSIZE(DBFCIPaletteNamesNormal), 0x4,  indexFrenchBreadSprites_DBFCI_Quenser },
+    { L"Stm.pal",    L"Rentaro",        65540,    DBFCIPaletteNamesNormal,    ARRAYSIZE(DBFCIPaletteNamesNormal), 0x4,  indexFrenchBreadSprites_DBFCI_Rentaro },
+    { L"Slv.pal",    L"Selvaria",       65540,    DBFCIPaletteNamesNormal,    ARRAYSIZE(DBFCIPaletteNamesNormal), 0x4,  indexFrenchBreadSprites_DBFCI_Selvaria },
+    { L"Sha.pal",    L"Shana",          65540,    DBFCIPaletteNamesNormal,    ARRAYSIZE(DBFCIPaletteNamesNormal), 0x4,  indexFrenchBreadSprites_DBFCI_Shana },
+    { L"Hiw.pal",    L"Shizuo",         65540,    DBFCIPaletteNamesNormal,    ARRAYSIZE(DBFCIPaletteNamesNormal), 0x4,  indexFrenchBreadSprites_DBFCI_Shizuo },
+    { L"Tgr.pal",    L"Taiga",          65540,    DBFCIPaletteNamesNormal,    ARRAYSIZE(DBFCIPaletteNamesNormal), 0x4,  indexFrenchBreadSprites_DBFCI_Taiga },
+    { L"Oni.pal",    L"Tatsuya",        65540,    DBFCIPaletteNamesNormal,    ARRAYSIZE(DBFCIPaletteNamesNormal), 0x4,  indexFrenchBreadSprites_DBFCI_Tatsuya },
+    { L"Tmk.pal",    L"Tomoka",         65540,    DBFCIPaletteNamesNormal,    ARRAYSIZE(DBFCIPaletteNamesNormal), 0x4,  indexFrenchBreadSprites_DBFCI_Tomoka },
+    { L"Ykn.pal",    L"Yukina",         65540,    DBFCIPaletteNamesNormal,    ARRAYSIZE(DBFCIPaletteNamesNormal), 0x4,  indexFrenchBreadSprites_DBFCI_Yukina },
+    { L"Yuk.pal",    L"Yuuki",          65540,    DBFCIPaletteNamesNormal,    ARRAYSIZE(DBFCIPaletteNamesNormal), 0x4,  indexFrenchBreadSprites_DBFCI_Yuuki },
     
     // Support characters
-    { L"Acr_s.pal",  L"Accelerator&Last Order", 65540, DBFCIPaletteNamesSupport,   ARRAYSIZE(DBFCIPaletteNamesSupport),     0x4,  indexDBFCSprites_DBFCI_AcceleratorLastOrder },
-    { L"Alc_s.pal",  L"Alicia",         65540,    DBFCIPaletteNamesSupport,        ARRAYSIZE(DBFCIPaletteNamesSupport),     0x4,  indexDBFCSprites_DBFCI_Alicia },
-    { L"Har_s.pal",  L"Arita",          65540,    DBFCIPaletteNamesSupport,        ARRAYSIZE(DBFCIPaletteNamesSupport),     0x4,  indexDBFCSprites_DBFCI_Arita },
-    { L"Bog_s.pal",  L"Boogiepop",      65540,    DBFCIPaletteNamesSupport,        ARRAYSIZE(DBFCIPaletteNamesSupport),     0x4,  indexDBFCSprites_DBFCI_Boogiepop },
-    { L"Crt_s.pal",  L"Celty",          65540,    DBFCIPaletteNamesSupport,        ARRAYSIZE(DBFCIPaletteNamesSupport),     0x4,  indexDBFCSprites_DBFCI_Celty },
-    { L"Dok_s.pal",  L"Dokuro-Chan",    65540,    DBFCIPaletteNamesSupport,        ARRAYSIZE(DBFCIPaletteNamesSupport),     0x4,  indexDBFCSprites_DBFCI_DokuroChan },
-    { L"Aen_s.pal",  L"Enju",           65540,    DBFCIPaletteNamesSupport,        ARRAYSIZE(DBFCIPaletteNamesSupport),     0x4,  indexDBFCSprites_DBFCI_Enju },
-    { L"Ero_s.pal",  L"Erio",           65540,    DBFCIPaletteNamesSupport,        ARRAYSIZE(DBFCIPaletteNamesSupport),     0x4,  indexDBFCSprites_DBFCI_Erio },
-    { L"Fro_s.pal",  L"Frolaytia",      65540,    DBFCIPaletteNamesSupport,        ARRAYSIZE(DBFCIPaletteNamesSupport),     0x4,  indexDBFCSprites_DBFCI_Frolaytia },
-    { L"Hol_s.pal",  L"Holo",           65540,    DBFCIPaletteNamesSupport,        ARRAYSIZE(DBFCIPaletteNamesSupport),     0x4,  indexDBFCSprites_DBFCI_Holo },
-    { L"Ino_s.pal",  L"Innocent Charm", 65540,    DBFCIPaletteNamesSupport,        ARRAYSIZE(DBFCIPaletteNamesSupport),     0x4,  indexDBFCSprites_DBFCI_InnocentCharm },
-    { L"Izy_s.pal",  L"Izaya",          65540,    DBFCIPaletteNamesSupport,        ARRAYSIZE(DBFCIPaletteNamesSupport),     0x4,  indexDBFCSprites_DBFCI_Izaya },
-    { L"Iry_s.pal",  L"Kana",           65540,    DBFCIPaletteNamesSupport,        ARRAYSIZE(DBFCIPaletteNamesSupport),     0x4,  indexDBFCSprites_DBFCI_Kana },
-    { L"Uih_s.pal",  L"Kazari",         65540,    DBFCIPaletteNamesSupport,        ARRAYSIZE(DBFCIPaletteNamesSupport),     0x4,  indexDBFCSprites_DBFCI_Kazari },
-    { L"Kin_s.pal",  L"Kino",           65540,    DBFCIPaletteNamesSupport,        ARRAYSIZE(DBFCIPaletteNamesSupport),     0x4,  indexDBFCSprites_DBFCI_Kino },
-    { L"Akj_s.pal",  L"Kojou",          65540,    DBFCIPaletteNamesSupport,        ARRAYSIZE(DBFCIPaletteNamesSupport),     0x4,  indexDBFCSprites_DBFCI_Kojou },
-    { L"Kgk_s.pal",  L"Kokou",          65540,    DBFCIPaletteNamesSupport,        ARRAYSIZE(DBFCIPaletteNamesSupport),     0x4,  indexDBFCSprites_DBFCI_Kokou },
-    { L"Kro_s.pal",  L"Kuroneko",       65540,    DBFCIPaletteNamesSupport,        ARRAYSIZE(DBFCIPaletteNamesSupport),     0x4,  indexDBFCSprites_DBFCI_Kuroneko },
-    { L"Lea_s.pal",  L"Leafa",          65540,    DBFCIPaletteNamesSupport,        ARRAYSIZE(DBFCIPaletteNamesSupport),     0x4,  indexDBFCSprites_DBFCI_Leafa },
-    { L"Ren_s.pal",  L"Llenn",          65540,    DBFCIPaletteNamesSupport,        ARRAYSIZE(DBFCIPaletteNamesSupport),     0x4,  indexDBFCSprites_DBFCI_Llenn },
-    { L"Mas_s.pal",  L"Mashiro",        65540,    DBFCIPaletteNamesSupport,        ARRAYSIZE(DBFCIPaletteNamesSupport),     0x4,  indexDBFCSprites_DBFCI_Mashiro },
-    { L"Smy_s.pal",  L"Miyuki Support", 66564,    DBFCIPaletteNamesSupport,        ARRAYSIZE(DBFCIPaletteNamesSupport),     0x4,  indexDBFCSprites_DBFCI_MiyukiAssist },
-    { L"Pai_s.pal",  L"Pai",            65540,    DBFCIPaletteNamesSupport,        ARRAYSIZE(DBFCIPaletteNamesSupport),     0x4,  indexDBFCSprites_DBFCI_PaiChan },
-    { L"Rus_s.pal",  L"Rusian",         65540,    DBFCIPaletteNamesSupport,        ARRAYSIZE(DBFCIPaletteNamesSupport),     0x4,  indexDBFCSprites_DBFCI_Rusian },
-    { L"Tks_s.pal",  L"Ryuji",          65540,    DBFCIPaletteNamesSupport,        ARRAYSIZE(DBFCIPaletteNamesSupport),     0x4,  indexDBFCSprites_DBFCI_Ryuji },
-    { L"Mou_s.pal",  L"Sadao",          65540,    DBFCIPaletteNamesSupport,        ARRAYSIZE(DBFCIPaletteNamesSupport),     0x4,  indexDBFCSprites_DBFCI_Sadao },
-    { L"Sbt_s.pal",  L"Tatsuya Support",65540,    DBFCIPaletteNamesSupport,        ARRAYSIZE(DBFCIPaletteNamesSupport),     0x4,  indexDBFCSprites_DBFCI_TatsuyaAssist },
-    { L"Asm_s.pal",  L"Tomo",           65540,    DBFCIPaletteNamesSupport,        ARRAYSIZE(DBFCIPaletteNamesSupport),     0x4,  indexDBFCSprites_DBFCI_Tomo },
-    { L"Tom_s.pal",  L"Touma",          65540,    DBFCIPaletteNamesSupport,        ARRAYSIZE(DBFCIPaletteNamesSupport),     0x4,  indexDBFCSprites_DBFCI_Touma },
-    { L"Wil_s.pal",  L"Wilhelmina",     65540,    DBFCIPaletteNamesSupport,        ARRAYSIZE(DBFCIPaletteNamesSupport),     0x4,  indexDBFCSprites_DBFCI_Wilhelmina },
-    { L"Zer_s.pal",  L"Zero",           65540,    DBFCIPaletteNamesSupport,        ARRAYSIZE(DBFCIPaletteNamesSupport),     0x4,  indexDBFCSprites_DBFCI_Zero },
+    { L"Acr_s.pal",  L"Accelerator&Last Order", 65540, DBFCIPaletteNamesSupport,   ARRAYSIZE(DBFCIPaletteNamesSupport),     0x4,  indexFrenchBreadSprites_DBFCI_AcceleratorLastOrder },
+    { L"Alc_s.pal",  L"Alicia",         65540,    DBFCIPaletteNamesSupport,        ARRAYSIZE(DBFCIPaletteNamesSupport),     0x4,  indexFrenchBreadSprites_DBFCI_Alicia },
+    { L"Har_s.pal",  L"Arita",          65540,    DBFCIPaletteNamesSupport,        ARRAYSIZE(DBFCIPaletteNamesSupport),     0x4,  indexFrenchBreadSprites_DBFCI_Arita },
+    { L"Bog_s.pal",  L"Boogiepop",      65540,    DBFCIPaletteNamesSupport,        ARRAYSIZE(DBFCIPaletteNamesSupport),     0x4,  indexFrenchBreadSprites_DBFCI_Boogiepop },
+    { L"Crt_s.pal",  L"Celty",          65540,    DBFCIPaletteNamesSupport,        ARRAYSIZE(DBFCIPaletteNamesSupport),     0x4,  indexFrenchBreadSprites_DBFCI_Celty },
+    { L"Dok_s.pal",  L"Dokuro-Chan",    65540,    DBFCIPaletteNamesSupport,        ARRAYSIZE(DBFCIPaletteNamesSupport),     0x4,  indexFrenchBreadSprites_DBFCI_DokuroChan },
+    { L"Aen_s.pal",  L"Enju",           65540,    DBFCIPaletteNamesSupport,        ARRAYSIZE(DBFCIPaletteNamesSupport),     0x4,  indexFrenchBreadSprites_DBFCI_Enju },
+    { L"Ero_s.pal",  L"Erio",           65540,    DBFCIPaletteNamesSupport,        ARRAYSIZE(DBFCIPaletteNamesSupport),     0x4,  indexFrenchBreadSprites_DBFCI_Erio },
+    { L"Fro_s.pal",  L"Frolaytia",      65540,    DBFCIPaletteNamesSupport,        ARRAYSIZE(DBFCIPaletteNamesSupport),     0x4,  indexFrenchBreadSprites_DBFCI_Frolaytia },
+    { L"Hol_s.pal",  L"Holo",           65540,    DBFCIPaletteNamesSupport,        ARRAYSIZE(DBFCIPaletteNamesSupport),     0x4,  indexFrenchBreadSprites_DBFCI_Holo },
+    { L"Ino_s.pal",  L"Innocent Charm", 65540,    DBFCIPaletteNamesSupport,        ARRAYSIZE(DBFCIPaletteNamesSupport),     0x4,  indexFrenchBreadSprites_DBFCI_InnocentCharm },
+    { L"Izy_s.pal",  L"Izaya",          65540,    DBFCIPaletteNamesSupport,        ARRAYSIZE(DBFCIPaletteNamesSupport),     0x4,  indexFrenchBreadSprites_DBFCI_Izaya },
+    { L"Iry_s.pal",  L"Kana",           65540,    DBFCIPaletteNamesSupport,        ARRAYSIZE(DBFCIPaletteNamesSupport),     0x4,  indexFrenchBreadSprites_DBFCI_Kana },
+    { L"Uih_s.pal",  L"Kazari",         65540,    DBFCIPaletteNamesSupport,        ARRAYSIZE(DBFCIPaletteNamesSupport),     0x4,  indexFrenchBreadSprites_DBFCI_Kazari },
+    { L"Kin_s.pal",  L"Kino",           65540,    DBFCIPaletteNamesSupport,        ARRAYSIZE(DBFCIPaletteNamesSupport),     0x4,  indexFrenchBreadSprites_DBFCI_Kino },
+    { L"Akj_s.pal",  L"Kojou",          65540,    DBFCIPaletteNamesSupport,        ARRAYSIZE(DBFCIPaletteNamesSupport),     0x4,  indexFrenchBreadSprites_DBFCI_Kojou },
+    { L"Kgk_s.pal",  L"Kokou",          65540,    DBFCIPaletteNamesSupport,        ARRAYSIZE(DBFCIPaletteNamesSupport),     0x4,  indexFrenchBreadSprites_DBFCI_Kokou },
+    { L"Kro_s.pal",  L"Kuroneko",       65540,    DBFCIPaletteNamesSupport,        ARRAYSIZE(DBFCIPaletteNamesSupport),     0x4,  indexFrenchBreadSprites_DBFCI_Kuroneko },
+    { L"Lea_s.pal",  L"Leafa",          65540,    DBFCIPaletteNamesSupport,        ARRAYSIZE(DBFCIPaletteNamesSupport),     0x4,  indexFrenchBreadSprites_DBFCI_Leafa },
+    { L"Ren_s.pal",  L"Llenn",          65540,    DBFCIPaletteNamesSupport,        ARRAYSIZE(DBFCIPaletteNamesSupport),     0x4,  indexFrenchBreadSprites_DBFCI_Llenn },
+    { L"Mas_s.pal",  L"Mashiro",        65540,    DBFCIPaletteNamesSupport,        ARRAYSIZE(DBFCIPaletteNamesSupport),     0x4,  indexFrenchBreadSprites_DBFCI_Mashiro },
+    { L"Smy_s.pal",  L"Miyuki Support", 66564,    DBFCIPaletteNamesSupport,        ARRAYSIZE(DBFCIPaletteNamesSupport),     0x4,  indexFrenchBreadSprites_DBFCI_MiyukiAssist },
+    { L"Pai_s.pal",  L"Pai",            65540,    DBFCIPaletteNamesSupport,        ARRAYSIZE(DBFCIPaletteNamesSupport),     0x4,  indexFrenchBreadSprites_DBFCI_PaiChan },
+    { L"Rus_s.pal",  L"Rusian",         65540,    DBFCIPaletteNamesSupport,        ARRAYSIZE(DBFCIPaletteNamesSupport),     0x4,  indexFrenchBreadSprites_DBFCI_Rusian },
+    { L"Tks_s.pal",  L"Ryuji",          65540,    DBFCIPaletteNamesSupport,        ARRAYSIZE(DBFCIPaletteNamesSupport),     0x4,  indexFrenchBreadSprites_DBFCI_Ryuji },
+    { L"Mou_s.pal",  L"Sadao",          65540,    DBFCIPaletteNamesSupport,        ARRAYSIZE(DBFCIPaletteNamesSupport),     0x4,  indexFrenchBreadSprites_DBFCI_Sadao },
+    { L"Sbt_s.pal",  L"Tatsuya Support",65540,    DBFCIPaletteNamesSupport,        ARRAYSIZE(DBFCIPaletteNamesSupport),     0x4,  indexFrenchBreadSprites_DBFCI_TatsuyaAssist },
+    { L"Asm_s.pal",  L"Tomo",           65540,    DBFCIPaletteNamesSupport,        ARRAYSIZE(DBFCIPaletteNamesSupport),     0x4,  indexFrenchBreadSprites_DBFCI_Tomo },
+    { L"Tom_s.pal",  L"Touma",          65540,    DBFCIPaletteNamesSupport,        ARRAYSIZE(DBFCIPaletteNamesSupport),     0x4,  indexFrenchBreadSprites_DBFCI_Touma },
+    { L"Wil_s.pal",  L"Wilhelmina",     65540,    DBFCIPaletteNamesSupport,        ARRAYSIZE(DBFCIPaletteNamesSupport),     0x4,  indexFrenchBreadSprites_DBFCI_Wilhelmina },
+    { L"Zer_s.pal",  L"Zero",           65540,    DBFCIPaletteNamesSupport,        ARRAYSIZE(DBFCIPaletteNamesSupport),     0x4,  indexFrenchBreadSprites_DBFCI_Zero },
 	
     // Extra/Trump Palettes
-    { L"Ako_p1.pal",  L"Ako (Rusian)",  65540,    DBFCIPaletteNamesEx,             ARRAYSIZE(DBFCIPaletteNamesEx),          0x4,  indexDBFCSprites_DBFCI_Rusian },
-    { L"Emi_p1.pal",  L"Emi (Trump)",   65540,    DBFCIPaletteNamesEx,             ARRAYSIZE(DBFCIPaletteNamesEx),          0x4,  indexDBFCSprites_DBFCI_Emi },
-    { L"Kur_p1.pal",  L"Kuroyukihime (Red)", 65540,   DBFCIPaletteNamesEx,         ARRAYSIZE(DBFCIPaletteNamesEx),          0x4,  indexDBFCSprites_DBFCI_Kuroyukihime },
-    { L"Kur_p2.pal",  L"Kuroyukihime (Green)", 65540,   DBFCIPaletteNamesEx,       ARRAYSIZE(DBFCIPaletteNamesEx),          0x4,  indexDBFCSprites_DBFCI_Kuroyukihime },
-    { L"Kur_p3.pal",  L"Kuroyukihime (Blue)", 65540,   DBFCIPaletteNamesEx,        ARRAYSIZE(DBFCIPaletteNamesEx),          0x4,  indexDBFCSprites_DBFCI_Kuroyukihime },
-    { L"Stm_p1.pal",  L"Rentaro (Trump)",   65540, DBFCIPaletteNamesEx,            ARRAYSIZE(DBFCIPaletteNamesEx),          0x4,  indexDBFCSprites_DBFCI_Rentaro },
-    { L"Tgr_p1.pal",  L"Taiga (Ryuji)",   65540,  DBFCIPaletteNamesEx,             ARRAYSIZE(DBFCIPaletteNamesEx),          0x4,  indexDBFCSprites_DBFCI_Ryuji },
-    { L"Oni_p1.pal",  L"Tatsuya (Miyuki)", 66564, DBFCIPaletteNamesEx,             ARRAYSIZE(DBFCIPaletteNamesEx),          0x4,  indexDBFCSprites_DBFCI_MiyukiAssist },
+    { L"Ako_p1.pal",  L"Ako (Rusian)",  65540,    DBFCIPaletteNamesEx,             ARRAYSIZE(DBFCIPaletteNamesEx),          0x4,  indexFrenchBreadSprites_DBFCI_Rusian },
+    { L"Emi_p1.pal",  L"Emi (Trump)",   65540,    DBFCIPaletteNamesEx,             ARRAYSIZE(DBFCIPaletteNamesEx),          0x4,  indexFrenchBreadSprites_DBFCI_Emi },
+    { L"Kur_p1.pal",  L"Kuroyukihime (Red)", 65540,   DBFCIPaletteNamesEx,         ARRAYSIZE(DBFCIPaletteNamesEx),          0x4,  indexFrenchBreadSprites_DBFCI_Kuroyukihime },
+    { L"Kur_p2.pal",  L"Kuroyukihime (Green)", 65540,   DBFCIPaletteNamesEx,       ARRAYSIZE(DBFCIPaletteNamesEx),          0x4,  indexFrenchBreadSprites_DBFCI_Kuroyukihime },
+    { L"Kur_p3.pal",  L"Kuroyukihime (Blue)", 65540,   DBFCIPaletteNamesEx,        ARRAYSIZE(DBFCIPaletteNamesEx),          0x4,  indexFrenchBreadSprites_DBFCI_Kuroyukihime },
+    { L"Stm_p1.pal",  L"Rentaro (Trump)",   65540, DBFCIPaletteNamesEx,            ARRAYSIZE(DBFCIPaletteNamesEx),          0x4,  indexFrenchBreadSprites_DBFCI_Rentaro },
+    { L"Tgr_p1.pal",  L"Taiga (Ryuji)",   65540,  DBFCIPaletteNamesEx,             ARRAYSIZE(DBFCIPaletteNamesEx),          0x4,  indexFrenchBreadSprites_DBFCI_Ryuji },
+    { L"Oni_p1.pal",  L"Tatsuya (Miyuki)", 66564, DBFCIPaletteNamesEx,             ARRAYSIZE(DBFCIPaletteNamesEx),          0x4,  indexFrenchBreadSprites_DBFCI_MiyukiAssist },
+
 };
 
 CGame_DBFCI_A::CGame_DBFCI_A(UINT32 nConfirmedROMSize /* = -1 */)
@@ -303,7 +304,7 @@ CGame_DBFCI_A::CGame_DBFCI_A(UINT32 nConfirmedROMSize /* = -1 */)
     InitDataBuffer();
 
     nGameFlag = DBFCI_A;
-    nImgGameFlag = IMGDAT_SECTION_DBFC;
+    nImgGameFlag = IMGDAT_SECTION_FRENCHBREAD;
     m_prgGameImageSet = DBFCI_A_IMG_UNITS;
     nImgUnitAmt = ARRAYSIZE(DBFCI_A_IMG_UNITS);
 

--- a/palmod/Game/Game_UNICLR_A.cpp
+++ b/palmod/Game/Game_UNICLR_A.cpp
@@ -10,28 +10,28 @@ CDescTree CGame_UNICLR_A::MainDescTree = nullptr;
 
 const UINT16 UNICLR_A_IMG_UNITS[] =
 {
-    indexFrenchBreadSprites_UNICLR_Akat,   // 0x00
-    indexFrenchBreadSprites_UNICLR_Byak,   // 0x01
-    indexFrenchBreadSprites_UNICLR_Carm,   // 0x02
-    indexFrenchBreadSprites_UNICLR_Chao,   // 0x03
-    indexFrenchBreadSprites_UNICLR_Eltn,   // 0x04
-    indexFrenchBreadSprites_UNICLR_Enki,   // 0x05
-    indexFrenchBreadSprites_UNICLR_Gord,   // 0x06
-    indexFrenchBreadSprites_UNICLR_Hild,   // 0x07
-    indexFrenchBreadSprites_UNICLR_Hyde,   // 0x08
-    indexFrenchBreadSprites_UNICLR_Linn,   // 0x09
-    indexFrenchBreadSprites_UNICLR_Lond,   // 0x0A
-    indexFrenchBreadSprites_UNICLR_Merk,   // 0x0B
-    indexFrenchBreadSprites_UNICLR_Mika,   // 0x0C
-    indexFrenchBreadSprites_UNICLR_Nana,   // 0x0D
-    indexFrenchBreadSprites_UNICLR_Orie,   // 0x0E
-    indexFrenchBreadSprites_UNICLR_Phon,   // 0x0F
-    indexFrenchBreadSprites_UNICLR_Seth,   // 0x10
-    indexFrenchBreadSprites_UNICLR_Vati,   // 0x11
-    indexFrenchBreadSprites_UNICLR_Wagn,   // 0x12
-    indexFrenchBreadSprites_UNICLR_Wald,   // 0x13
-    indexFrenchBreadSprites_UNICLR_Yuzu,   // 0x14
-    indexFrenchBreadSprites_UNICLR_Bonus,  // 0x15
+	indexFrenchBreadSprites_UNICLR_Akat,   // 0x34
+    indexFrenchBreadSprites_UNICLR_Byak,   // 0x35
+    indexFrenchBreadSprites_UNICLR_Carm,   // 0x36
+    indexFrenchBreadSprites_UNICLR_Chao,   // 0x37
+    indexFrenchBreadSprites_UNICLR_Eltn,   // 0x38
+    indexFrenchBreadSprites_UNICLR_Enki,   // 0x39
+    indexFrenchBreadSprites_UNICLR_Gord,   // 0x3A
+    indexFrenchBreadSprites_UNICLR_Hild,   // 0x3B
+    indexFrenchBreadSprites_UNICLR_Hyde,   // 0x3C
+    indexFrenchBreadSprites_UNICLR_Linn,   // 0x3D
+    indexFrenchBreadSprites_UNICLR_Lond,   // 0x3E
+    indexFrenchBreadSprites_UNICLR_Merk,   // 0x3F
+    indexFrenchBreadSprites_UNICLR_Mika,   // 0x40
+    indexFrenchBreadSprites_UNICLR_Nana,   // 0x41
+    indexFrenchBreadSprites_UNICLR_Orie,   // 0x42
+    indexFrenchBreadSprites_UNICLR_Phon,   // 0x43
+    indexFrenchBreadSprites_UNICLR_Seth,   // 0x44
+    indexFrenchBreadSprites_UNICLR_Vati,   // 0x45
+    indexFrenchBreadSprites_UNICLR_Wagn,   // 0x46
+    indexFrenchBreadSprites_UNICLR_Wald,   // 0x47
+    indexFrenchBreadSprites_UNICLR_Yuzu,   // 0x48
+    indexFrenchBreadSprites_UNICLR_Bonus,  // 0x49
 };
 
 struct UNICLRNodeData

--- a/palmod/ImgDat.cpp
+++ b/palmod/ImgDat.cpp
@@ -382,7 +382,7 @@ BOOL CImgDat::LoadGameImages(WCHAR* lpszLoadFile, UINT8 uGameFlag, UINT8 uImgGam
         for (int nGameCtr = 0; nGameCtr < uNumGames; nGameCtr++)
         {
             ImgDatFile.Read(&uReadGameFlag, 0x01);
-            ImgDatFile.Read(&uReadBPP, 0x01);
+            //ImgDatFile.Read(&uReadBPP, 0x01);
             ImgDatFile.Read(&uReadNumImgs, 0x02);
             ImgDatFile.Read(&uReadNextImgLoc, 0x04);
 

--- a/palmod/ImgDat.h
+++ b/palmod/ImgDat.h
@@ -17,7 +17,7 @@ private:
     UINT16 nCurImgGameFlag = 0xFFFF;
 
     UINT8 uReadGameFlag = 0x00;
-    UINT8 uReadBPP = 0x00;
+    //UINT8 uReadBPP = 0x00;
     UINT16 uReadNumImgs = 0x0000;
     UINT32 uReadNextImgLoc = 0x00000000;
 


### PR DESCRIPTION
The Imgdat has been changed to include DBFCI and UNICLR into one section FRENCHBREAD. GameDef has been updated to remove the old identifier and merge DBFCI and UNICLR into one section. The ImgDat's have had uReadBPP commented out as requested by TV